### PR TITLE
Exam timer and candidates

### DIFF
--- a/src/main/java/org/examportal/Controllers/CollegeController.java
+++ b/src/main/java/org/examportal/Controllers/CollegeController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.util.List;
+import java.util.Set;
 
 @Tag(name = "APIs for Colleges")
 @RestController
@@ -38,6 +39,17 @@ public class CollegeController {
         response.setResponseCode(HttpStatus.CREATED.value());
         response.setMessage(UserMessages.COLLEGE_ADDED);
         return new ResponseEntity<>(response, HttpStatus.CREATED);
+    }
+
+    @SecurityRequirement(name = "Bear Authentication")
+    @PreAuthorize("hasAnyAuthority('ADMIN', 'USER')")
+    @GetMapping("/")
+    public ResponseEntity<BaseResponseDto<Set<CollegeDto>>> getAllColleges() {
+        Set<CollegeDto> colleges = collegeService.findAll();
+        Response<Set<CollegeDto>> response = new Response<>(colleges, colleges.size(), colleges.isEmpty());
+        response.setResponseCode(colleges.isEmpty() ? HttpStatus.NO_CONTENT.value() : HttpStatus.OK.value());
+        if (colleges.isEmpty()) response.setMessage("No colleges found");
+        return new ResponseEntity<>(response, colleges.isEmpty() ? HttpStatus.NO_CONTENT : HttpStatus.OK);
     }
 
     @SecurityRequirement(name = "Bear Authentication")

--- a/src/main/java/org/examportal/Controllers/Exam/ExamController.java
+++ b/src/main/java/org/examportal/Controllers/Exam/ExamController.java
@@ -20,7 +20,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
-import java.util.Set;
+import java.util.*;
 
 @Slf4j
 @RestController
@@ -167,5 +167,38 @@ public class ExamController {
         response.setMessage(response.getData().isEmpty() ? UserMessages.NO_CONTENT : ExamMessages.EXAM_FETCHED);
         log.info(String.format("getAllActiveExams() - end %s", paginated.getContent()));
         return new ResponseEntity<>(response, response.getData().isEmpty() ? HttpStatus.NO_CONTENT : HttpStatus.OK);
+    }
+
+    // Get candidates for an exam (ADMIN)
+    @SecurityRequirement(name = "Bear Authentication")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @GetMapping("/{examId}/candidates")
+    public ResponseEntity<Response<List<Map<String, Object>>>> getExamCandidates(@PathVariable Long examId) {
+        log.info("getExamCandidates() - start examId={}", examId);
+        org.examportal.Models.Exam.Exam exam = examService.getExamEntity(examId);
+        List<org.examportal.Models.Candidate> candidates = examService.getCandidatesByExamId(examId);
+
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (org.examportal.Models.Candidate c : candidates) {
+            Map<String, Object> map = new LinkedHashMap<>();
+            map.put("candidateId", c.getId());
+            map.put("username", c.getUser() != null ? c.getUser().getUsername() : "N/A");
+            map.put("email", c.getEmail());
+            map.put("enrollmentNumber", c.getEnrollmentNumber());
+            map.put("contactNumber", c.getContactNumber());
+            map.put("collegeName", c.getCollege() != null ? c.getCollege().getName() : "N/A");
+            map.put("status", c.getCandidateStatus() != null ? c.getCandidateStatus().name() : "NOT_ATTENDED");
+            map.put("score", c.getScore());
+            map.put("totalQuestions", c.getTotalQuestions());
+            map.put("examStartTime", c.getExamStartTime());
+            map.put("examEndTime",   c.getExamEndTime());
+            result.add(map);
+        }
+
+        Response<List<Map<String, Object>>> response = new Response<>(result, result.size(), result.isEmpty());
+        response.setResponseCode(result.isEmpty() ? HttpStatus.NO_CONTENT.value() : HttpStatus.OK.value());
+        response.setMessage(result.isEmpty() ? "No candidates found" : "Candidates fetched");
+        log.info("getExamCandidates() - end, count={}", result.size());
+        return new ResponseEntity<>(response, result.isEmpty() ? HttpStatus.NO_CONTENT : HttpStatus.OK);
     }
 }

--- a/src/main/java/org/examportal/Controllers/Exam/StudentExamController.java
+++ b/src/main/java/org/examportal/Controllers/Exam/StudentExamController.java
@@ -117,4 +117,17 @@ public class StudentExamController {
         log.info("getExamResult() - end");
         return ResponseEntity.ok(response);
     }
+
+    // Get time remaining for an in-progress exam
+    @GetMapping("/{examId}/time-remaining")
+    public ResponseEntity<Response<ExamTimingDto>> getTimeRemaining(
+            @PathVariable Long examId, Principal principal) {
+        log.info("getTimeRemaining() - start examId={}", examId);
+        ExamTimingDto timing = studentExamService.getExamTiming(examId, principal.getName());
+        Response<ExamTimingDto> response = new Response<>(timing);
+        response.setResponseCode(HttpStatus.OK.value());
+        response.setMessage("Exam timing fetched");
+        log.info("getTimeRemaining() - end");
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/org/examportal/DTOs/Exam/ExamTimingDto.java
+++ b/src/main/java/org/examportal/DTOs/Exam/ExamTimingDto.java
@@ -1,0 +1,16 @@
+package org.examportal.DTOs.Exam;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ExamTimingDto {
+    private LocalDateTime examEndTime;
+    private LocalDateTime serverTime;
+    private String examTitle;
+    private Long examTimeMinutes;
+}

--- a/src/main/java/org/examportal/Repositories/CandidateRepository.java
+++ b/src/main/java/org/examportal/Repositories/CandidateRepository.java
@@ -15,4 +15,6 @@ public interface CandidateRepository extends JpaRepository<Candidate, Long> {
     Optional<Candidate> findByUserAndExam(User user, Exam exam);
 
     Long countByExamId(Long examId);
+
+    List<Candidate> findByExamId(Long examId);
 }

--- a/src/main/java/org/examportal/Repositories/Exam/QuestionsRepository.java
+++ b/src/main/java/org/examportal/Repositories/Exam/QuestionsRepository.java
@@ -23,7 +23,7 @@ public interface QuestionsRepository extends JpaRepository<Questions, Long> {
     Page<Questions> findAllWithFilters(@Param("searchData") String searchData, Pageable pageable);
 
     @Query("SELECT q.answer FROM Questions q WHERE q.id = :questionId")
-    Options findAnswerById(Long questionId);
+    Options findAnswerById(@Param("questionId") Long questionId);
 
     @Query(value = "SELECT q.id FROM questions q INNER JOIN question_category qc ON q.id = qc.question_id " +
             "WHERE qc.category_id IN (:categoryIds) ORDER BY RAND() LIMIT :limit", nativeQuery = true)

--- a/src/main/java/org/examportal/Services/Exam/ExamService.java
+++ b/src/main/java/org/examportal/Services/Exam/ExamService.java
@@ -25,4 +25,8 @@ public interface ExamService {
     ExamDto getExam(Long examId);
 
     void deleteExam(Long examId);
+
+    org.examportal.Models.Exam.Exam getExamEntity(Long examId);
+
+    java.util.List<org.examportal.Models.Candidate> getCandidatesByExamId(Long examId);
 }

--- a/src/main/java/org/examportal/Services/Exam/StudentExamService.java
+++ b/src/main/java/org/examportal/Services/Exam/StudentExamService.java
@@ -2,6 +2,7 @@ package org.examportal.Services.Exam;
 
 import org.examportal.DTOs.Exam.ExamDto;
 import org.examportal.DTOs.Exam.ExamResultDto;
+import org.examportal.DTOs.Exam.ExamTimingDto;
 import org.examportal.DTOs.Exam.StudentExamQuestionDto;
 import org.examportal.DTOs.Exam.SubmitAnswerDto;
 import org.springframework.data.domain.Page;
@@ -22,4 +23,6 @@ public interface StudentExamService {
     ExamResultDto finishExam(Long examId, String username);
 
     ExamResultDto getExamResult(Long examId, String username);
+
+    ExamTimingDto getExamTiming(Long examId, String username);
 }

--- a/src/main/java/org/examportal/Services/Impl/Exam/ExamServiceImpl.java
+++ b/src/main/java/org/examportal/Services/Impl/Exam/ExamServiceImpl.java
@@ -54,10 +54,16 @@ public class ExamServiceImpl implements ExamService {
     @Override
     public ExamDto updateExam(ExamDto exam, String user) {
         log.info(String.format("updateExam - start %s", exam));
+        
+        Exam existingExam = examRepository.findById(exam.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("Exam", "id", exam.getId()));
+                
         Exam savedExam = modelMapper.map(exam, Exam.class);
+        savedExam.setExamCode(existingExam.getExamCode());
+        
         savedExam.update(user);
         examRepository.save(savedExam);
-        ExamDto examDto = modelMapper.map(exam, ExamDto.class);
+        ExamDto examDto = modelMapper.map(savedExam, ExamDto.class);
         log.info(String.format("updateExam - end %s", savedExam));
         return examDto;
     }
@@ -135,5 +141,16 @@ public class ExamServiceImpl implements ExamService {
         Exam exam = examRepository.findById(examId).orElseThrow(() -> new ResourceNotFoundException("Exam", "id", examId));
         log.info(String.format("deleteExam - end %s", exam));
         examRepository.delete(exam);
+    }
+
+    @Override
+    public Exam getExamEntity(Long examId) {
+        return examRepository.findById(examId)
+                .orElseThrow(() -> new ResourceNotFoundException("Exam", "id", examId));
+    }
+
+    @Override
+    public java.util.List<Candidate> getCandidatesByExamId(Long examId) {
+        return candidateRepository.findByExamId(examId);
     }
 }

--- a/src/main/java/org/examportal/Services/Impl/Exam/StudentExamServiceImpl.java
+++ b/src/main/java/org/examportal/Services/Impl/Exam/StudentExamServiceImpl.java
@@ -306,8 +306,34 @@ public class StudentExamServiceImpl implements StudentExamService {
         result.setExamTitle(exam.getTitle());
         result.setTotalQuestions(totalQuestions);
         result.setCorrectAnswers(correctCount);
-        result.setTotalMarks(totalQuestions); // each question = 1 mark
-        result.setScoredMarks(correctCount); // each question = 1 mark
+        result.setTotalMarks(totalQuestions);
+        result.setScoredMarks(correctCount);
         return result;
+    }
+
+    @Override
+    public ExamTimingDto getExamTiming(Long examId, String username) {
+        log.info("getExamTiming - start examId={} username={}", examId, username);
+
+        User user = userRepository.findByUsernameOrEmail(username, username)
+                .orElseThrow(() -> new RuntimeException("User not found with username: " + username));
+        Exam exam = examRepository.findById(examId)
+                .orElseThrow(() -> new ResourceNotFoundException("Exam", "id", examId));
+
+        Candidate candidate = candidateRepository.findByUserAndExam(user, exam)
+                .orElseThrow(() -> new RuntimeException(ExamMessages.EXAM_NOT_STARTED));
+
+        if (candidate.getCandidateStatus() != ExamStatus.ATTENDING) {
+            throw new RuntimeException("Exam is not in progress");
+        }
+
+        ExamTimingDto timingDto = new ExamTimingDto();
+        timingDto.setExamEndTime(candidate.getExamEndTime());
+        timingDto.setServerTime(LocalDateTime.now());
+        timingDto.setExamTitle(exam.getTitle());
+        timingDto.setExamTimeMinutes(exam.getExamTime());
+
+        log.info("getExamTiming - end");
+        return timingDto;
     }
 }


### PR DESCRIPTION
- Created `GET /api/student/exam/{examId}/time-remaining` endpoint returning `examEndTime` and server time for cheat-proof clock synchronization
- Added `GET /api/exam/{examId}/candidates` endpoint to securely aggregate candidate progression for a specific exam
- Added `GET /api/college/` endpoint enabling the USER role to fetch colleges for registration
- Fixed critical bug causing `examCode` to be nullified when an admin updates an existing exam